### PR TITLE
Fixed Metric Printing when printMatchedString is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changes
 =======
+## 4.0.2 (June 2020)
+* Fixed metric printing when printMatchedString is enabled
+
 ## 4.0.1 (April 2020)
 * Upgraded to Extensions SDK v2.2.2 to resolve log4j & slf4j discrepancies
 * Extension compatible with MA 4.5.x and 20.3.x+. 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Always feel free to fork and contribute any changes directly via [GitHub](https:
 ## Version
 |          Name            |  Version   |
 |--------------------------|------------|
-|Extension Version         |4.0.0       |
+|Extension Version         |4.0.2       |
 |Controller Compatibility  |4.0 or Later|
-|Last Update               |12/11/2019 |
+|Last Update               |28/06/2020 |
 |List of Changes           |[Change log](https://github.com/Appdynamics/log-monitoring-extension/blob/master/CHANGELOG.md) |

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>log-monitoring-extension</groupId>
     <artifactId>log-monitoring-extension</artifactId>
-    <version>4.0.1</version>
+    <version>4.0.2</version>
     <name>Log Monitor</name>
     <description>Inspects logs and counts the number of occurrences of specified search terms</description>
 
@@ -46,6 +46,11 @@
             <artifactId>powermock-module-junit4</artifactId>
             <version>1.5.6</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.20.0-GA</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/appdynamics/extensions/logmonitor/processors/LogMetricsProcessor.java
+++ b/src/main/java/com/appdynamics/extensions/logmonitor/processors/LogMetricsProcessor.java
@@ -15,6 +15,8 @@ import com.appdynamics.extensions.logmonitor.config.Log;
 import com.appdynamics.extensions.logmonitor.config.SearchPattern;
 import com.appdynamics.extensions.logmonitor.metrics.LogMetrics;
 import com.appdynamics.extensions.metrics.Metric;
+import com.appdynamics.extensions.util.MetricPathUtils;
+import com.google.common.base.Strings;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.WordUtils;
 import org.bitbucket.kienerj.OptimizedRandomAccessFile;
@@ -115,14 +117,17 @@ public class LogMetricsProcessor implements Runnable {
                         logMetrics.getMetricPrefix() + METRIC_SEPARATOR + metricName));
 
                 if (searchPattern.getPrintMatchedString()) {
+                    String path;
                     LOGGER.info("Adding actual matches to the queue for printing for log: {}", log.getDisplayName());
                     String replacedWord = matcher.group().trim();
                     if (searchPattern.getCaseSensitive()) {
-                        metricName = currentKey + MATCHES + replacedWord;
+                        metricName = currentKey+MATCHES+METRIC_SEPARATOR+replacedWord;
+                        path = MetricPathUtils.buildMetricPath(currentKey,MATCHES,replacedWord);
                     } else {
-                        metricName = currentKey + MATCHES + WordUtils.capitalizeFully(replacedWord);
+                        metricName = currentKey+MATCHES+METRIC_SEPARATOR+WordUtils.capitalizeFully(replacedWord);
+                        path = MetricPathUtils.buildMetricPath(currentKey,MATCHES,WordUtils.capitalizeFully(replacedWord));
                     }
-                    logMetrics.add(metricName, logMetrics.getMetricPrefix() + METRIC_SEPARATOR + metricName);
+                    logMetrics.add(metricName, logMetrics.getMetricPrefix() + METRIC_SEPARATOR + path);
                 }
 
                 if (logEventsProcessor != null) {

--- a/src/main/java/com/appdynamics/extensions/logmonitor/util/Constants.java
+++ b/src/main/java/com/appdynamics/extensions/logmonitor/util/Constants.java
@@ -19,6 +19,6 @@ public final class Constants {
     public static final String DEFAULT_METRIC_PREFIX = "Custom Metrics|Log Monitor|";
     public static final String MONITOR_NAME = "Log Monitor";
     public static final String OCCURRENCES = "Occurrences";
-    public static final String MATCHES = "Matches|";
+    public static final String MATCHES = "Matches";
     public static final String SCHEMA_NAME = "LogSchema";
 }

--- a/src/main/resources/conf/config.yml
+++ b/src/main/resources/conf/config.yml
@@ -21,13 +21,21 @@ logs:
 #Replaces characters in metric name with the specified characters.
 # "replace" takes any regular expression
 # "replaceWith" takes the string to replace the matched characters
-metricCharacterReplacer:
+metricPathReplacements:
 - replace: ":"
   replaceWith: ";"
-- replace: "\\|"
+- replace: "|"
+  replaceWith: "="
+- replace: ","
   replaceWith: "#"
-- replace: "\\,"
-  replaceWith: "#"
+
+#metricCharacterReplacer:
+#  - replace: ":"
+#    replaceWith: ";"
+#  - replace: "\\|"
+#    replaceWith: "#"
+#  - replace: "\\,"
+#    replaceWith: "#"
 
 # Number of concurrent threads
 numberOfThreads: 20
@@ -78,4 +86,4 @@ controllerInfo:
   tierName: "" # -Dappdynamics.agent.tierName
   nodeName: "" # -Dappdynamics.agent.nodeName
 
-enableHealthChecks: true # If not set, will be retrieved from "-Dappdynamics.agent.monitors.healthchecks.enable=true". Defaults to true.
+enableHealthChecks: false # If not set, will be retrieved from "-Dappdynamics.agent.monitors.healthchecks.enable=true". Defaults to true.

--- a/src/test/java/com/appdynamics/extensions/logmonitor/processors/LogFileManagerTest.java
+++ b/src/test/java/com/appdynamics/extensions/logmonitor/processors/LogFileManagerTest.java
@@ -19,12 +19,18 @@ import com.appdynamics.extensions.logmonitor.config.SearchString;
 import com.appdynamics.extensions.logmonitor.metrics.LogMetrics;
 import com.appdynamics.extensions.logmonitor.util.LogMonitorUtil;
 import com.appdynamics.extensions.metrics.Metric;
+import com.appdynamics.extensions.util.MetricPathUtils;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.bitbucket.kienerj.OptimizedRandomAccessFile;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.*;
 import java.nio.channels.FileChannel;
@@ -37,18 +43,21 @@ import java.util.regex.Pattern;
 import static com.appdynamics.extensions.logmonitor.util.Constants.SCHEMA_NAME;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * @author Aditya Jagtiani
  */
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(MetricPathUtils.class)
+@PowerMockIgnore({ "javax.net.ssl.*" })
 public class LogFileManagerTest {
     private LogFileManager classUnderTest;
     private FilePointerProcessor mockFilePointerProcessor = Mockito.mock(FilePointerProcessor.class);
     private MonitorContextConfiguration monitorContextConfiguration = new MonitorContextConfiguration("Log Monitor",
             "Custom Metrics|Log Monitor|", Mockito.mock(File.class), Mockito.mock(AMonitorJob.class));
+
 
     @Test
     public void testProcessorWhenPrintMatchedStringIsFalse() throws Exception {
@@ -101,6 +110,7 @@ public class LogFileManagerTest {
 
     @Test
     public void testProcessorWhenPrintMatchedStringIsTrue() throws Exception {
+        PowerMockito.mockStatic(MetricPathUtils.class);
         Log log = new Log();
         log.setDisplayName("TestLog");
         log.setLogDirectory("src/test/resources/");
@@ -201,6 +211,7 @@ public class LogFileManagerTest {
 
     @Test
     public void testProcessorForRegexPatternMatch() throws Exception {
+        PowerMockito.mockStatic(MetricPathUtils.class);
         Log log = new Log();
         log.setDisplayName("TestLog");
         log.setLogDirectory("src/test/resources/");
@@ -279,6 +290,7 @@ public class LogFileManagerTest {
 
     @Test
     public void testProcessorForRegexWordMatch() throws Exception {
+        PowerMockito.mockStatic(MetricPathUtils.class);
         Log log = new Log();
         log.setDisplayName("TestLog");
         log.setLogDirectory("src/test/resources/");
@@ -341,6 +353,7 @@ public class LogFileManagerTest {
     
     @Test
     public void testLogFileAfterAdditionOfMoreLogs() throws Exception {
+        PowerMockito.mockStatic(MetricPathUtils.class);
         String originalFilePath = this.getClass().getClassLoader().getResource("test-log-1.log").getPath();
 
         String testFilename = "active-test-log.log";

--- a/src/test/resources/conf/config-eventsService.yaml
+++ b/src/test/resources/conf/config-eventsService.yaml
@@ -9,9 +9,9 @@ logs:
          caseSensitive: false
          printMatchedString: false
 
-metricCharacterReplacer:
-    - replace: ","
-      replaceWith: " "
+metricPathReplacements:
+  - replace: ","
+    replaceWith: " "
 # Number of concurrent threads
 numberOfThreads: 10
 

--- a/src/test/resources/conf/config.yaml
+++ b/src/test/resources/conf/config.yaml
@@ -62,9 +62,9 @@ logs:
          caseSensitive: false
          printMatchedString: false
 
-metricCharacterReplacer:
-    - replace: ","
-      replaceWith: " "
+metricPathReplacements:
+  - replace: ","
+    replaceWith: " "
 # Number of concurrent threads
 numberOfThreads: 10
 


### PR DESCRIPTION
Fixed printing of metrics when printMatchedString is enabled in config.yml. Now it replaces special characters from the "metricPathReplacements" set in config.yml